### PR TITLE
Updated bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,6 @@
   "description": "Minimalistic but perfect custom scrollbar plugin",
   "main": [
     "css/perfect-scrollbar.css",
-    "js/perfect-scrollbar.jquery.js",
     "js/perfect-scrollbar.js"
   ],
   "license": "MIT",


### PR DESCRIPTION
I removed perfect-scrollbar.jquery.js from **main** field to prevent the **invalid-meta** message by bower install:

> The "main" field has to contain only 1 file per filetype; found multiple .js files: ["js/perfect-scrollbar.jquery.js","js/perfect-scrollbar.js"]

Missed something?